### PR TITLE
データベース設計のアンチパターンを学ぶ5

### DIFF
--- a/database_design/データベース設計のアンチパターンを学ぶ5/salesforce.pu
+++ b/database_design/データベース設計のアンチパターンを学ぶ5/salesforce.pu
@@ -1,0 +1,50 @@
+@startuml salesforce
+
+' TABLE NewCustomer {
+'   id: varchar
+'   called: boolean -- 電話をかけたらTRUEになる。FALSEの人には電話をかけなければいけない
+'   callNote: varchar -- 電話をかけた時に交わした内容のメモ
+'   metOnce: boolean -- アポで面談したらTRUEになる
+'   metAt: date -- 面談をした日付が入る
+'   closed: boolean -- 成約した
+'   closedAt: boolean -- 成約した日付が入る
+' }
+
+entity Customers {
+  CustomerID
+  --
+  tel
+  called
+  metOnce
+  closed
+}
+
+entity Calls {
+  CallID
+  --
+  CustomerID
+  callNote
+  callAt
+}
+
+entity Mets {
+  MetsID
+  --
+  CustomerID
+  metNote
+  metAt
+}
+
+entity Closes {
+  CloseID
+  --
+  CustomerID
+  closeNote
+  closedAt
+}
+
+Customers ||...o{ Calls
+Customers ||...o{ Mets
+Customers ||...o{ Closes
+
+@enduml


### PR DESCRIPTION
## 課題1
> 例えば商談の数が増えたらどうなるでしょうか？
- 面談の数が増えたらNewCustomerにレコードを新しく作るしかなく、同じ顧客かどうかがわからない。

> 仮に面談を3回実施して、1回目の面談日時を知りたい時はどうすれば良いのでしょうか？
- 現状のテーブルだと、面談する度にNewCustomerにレコードが増えていくが、1回目と3回目の顧客のつながりがないため、現状のままだと1回目の面談日時を取得するのは不可能。NewCustomerにTelを追加して、Telで顧客を検索し、面談日時で並べ替えをし、一番古い日が1回目の面談日時として取得できる。

> 例えば一度成約した後に解約し、後にまた同じ人が成約したらどうなるでしょうか？
- NewCustomerに新しくレコードが登録される。同じ顧客かはわからない。

## 課題2
- NewCustomerからCustomersに変更し、顧客の識別のためにTEL(電話番号)を追加。その他のカラムは電話をしたか、面談をしたか、成約をしたかの状態を持つ
- 電話、アポ、面談を全てそれぞれテーブルに切り分け、Customersの従属テーブルにした
  - 電話も面談前に複数回行うかもしれない想定にした。電話した日付も持つようにした
  > 仮に面談を3回実施して、1回目の面談日時を知りたい時はどうすれば良いのでしょうか？
  - 上記の想定のため、面談テーブルをCustomersの従属テーブルにした。面談時のメモも持つようにした。
  - 修正前でも成約の状態だけなら判断できるが、顧客が前回の成約日を知りたい、何回成約しているのかが知りたいなどの想定をしてCustomersの従属テーブルにした。成約のメモも持つようにした。
[![Image from Gyazo](https://i.gyazo.com/c742b3917bb1e56eb55a1beba798fed8.png)](https://gyazo.com/c742b3917bb1e56eb55a1beba798fed8)

## 課題3
- 求人サイト。求職者のステータスや申込日、面談日などを1テーブルで管理する
